### PR TITLE
Update widget test with OPJMasterApp

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,11 +9,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:opj_master/main.dart';
+import 'package:opj_master/services/statistics_service.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    // Build our app and trigger a frame with OPJMasterApp.
+    await tester.pumpWidget(OPJMasterApp(
+      statisticsService: StatisticsService(),
+    ));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- use `OPJMasterApp` in `widget_test.dart`
- provide `StatisticsService` instance when pumping the widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862dc8d0fa8832db4e8073346baf6f8